### PR TITLE
Add prop that allows UI to initiate transactions from their end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digix/react-ledger-container",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "React component for handling Ledger connectivity",
   "author": "Chris Hitchcott <hitchcott@gmail.com> (http://hitchcott.com)",
   "main": "lib/index.js",


### PR DESCRIPTION
Ref: [DGDG-470](https://tracker.digixdev.com/issue/DGDG-470)

Bumps package to version `0.1.8`.

This gives the UI greater control in updating transaction options (such as the gas price) by having the optional `renderInitSigning` prop. `renderInitSigning` should render the new UI that indicates that the transaction can be initiated by the user. `initiateSigning` is returned to the UI as a callback that readies the ledger device for signing the transaction. See PR [#10](https://github.com/DigixGlobal/governance-ui/pull/10) in the `governance-ui` repo for an example of how this is used.

Since the prop is optional, this should still be backwards-compatible with interfaces that do not need to manually initiate transactions.

**Test Plan**
- To test locally pre-publicaton, pull this branch and run `npm run compile`.
- Edit `package.json` of the repo that uses this package (e.g. marketplace, DAO) and point it to your local copy. e.g. `"@digix/react-ledger-container": "file:../path/to/react-ledger-container`.
- Run `npm i react-ledger-container`.

**Test Cases**
- PR [#10](https://github.com/DigixGlobal/governance-ui/pull/10) in `governance-ui` should pass.
- Regression tests for using ledger wallet in the marketplace should pass.