### PR TITLE
[FIX] Fix loading of ledger wallets with updated ledger library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digix/react-ledger-container",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "React component for handling Ledger connectivity",
   "author": "Chris Hitchcott <hitchcott@gmail.com> (http://hitchcott.com)",
   "main": "lib/index.js",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -76,7 +76,7 @@ export default class LedgerContainer extends Component {
                 }
                 return resolve();
               })
-              .fail(reject);
+              .catch(reject);
           } catch (err) {
             reject(err);
           }
@@ -128,9 +128,9 @@ export default class LedgerContainer extends Component {
               });
               resolve();
             })
-            .fail(reject);
+            .catch(reject);
         })
-        .fail(reject);
+        .catch(reject);
     });
   }
 

--- a/src/signing.js
+++ b/src/signing.js
@@ -73,7 +73,7 @@ export function signTransaction({ ethLedger, kdPath, txData }) {
         const signedTx = addHexPrefix(sTx.serialize().toString('hex'));
         return resolve(signedTx);
       })
-      .fail(reject);
+      .catch(reject);
   });
 }
 
@@ -118,6 +118,6 @@ export function signMessage({ ethLedger, kdPath, txData }) {
 
         return resolve(signedTx);
       })
-      .fail(reject);
+      .catch(reject);
   });
 }


### PR DESCRIPTION
The library was updated to `v0.1.9` which updates some of the dependencies to fix security issues. The change requires `then...fail` code blocks to be updated to `then...catch` so they're compiled properly.

This bumps the version to `v0.1.10`.